### PR TITLE
Finalizing Week 5

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,12 +14,7 @@
 
 package com.google.sps;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public final class FindMeetingQuery {
 
@@ -36,7 +31,11 @@ public final class FindMeetingQuery {
     int desiredDuration = (int) request.getDuration();
 
     // Collection of string representing who is to attend the requested meeting.
-    Collection<String> requestAttendees = request.getAttendees();
+    Collection<String> allAttendees = new ArrayList<>(request.getAttendees());
+    // Collection of strings representing who are optional to the meeting.
+    Collection<String> optionalAttendees = new ArrayList<>(request.getOptionalAttendees());
+    // Combine the optional and mandatory attendees to a single collection
+    allAttendees.addAll(optionalAttendees);
 
     // Check if duration of event is longer than a whole day and if so return empty.
     if ((int) request.getDuration() > WHOLE_DAY.duration()) {
@@ -45,7 +44,7 @@ public final class FindMeetingQuery {
 
     // Check if there are any events happening at all if so return whole day query.
     if (events.size() == 0) {
-      query.add(TimeRange.WHOLE_DAY);
+      query.add(com.google.sps.TimeRange.WHOLE_DAY);
       return query;
     }
 
@@ -58,14 +57,14 @@ public final class FindMeetingQuery {
     int nextTime = START_OF_DAY;
 
     // Iterating through input event collection.
-    for (Event event : eventsCopy) {
+    for (com.google.sps.Event event : eventsCopy) {
       int currentTime = nextTime;
 
-      // Collection of the people who are required to attend meeting.
+      // Collection of the people who can attend meeting.
       Set<String> eventAttendees = event.getAttendees();
 
-      // If the none of the attenddess are required attendees skip this event
-      if (Collections.disjoint(eventAttendees, requestAttendees)) {
+      // If the none of the attendees are capable of attending skip this event
+      if (Collections.disjoint(eventAttendees, allAttendees)) {
         continue;
       }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -158,7 +158,7 @@ public final class FindMeetingQuery {
     return allAttendees;
   }
   public List<TimeRange> populateTimeRanges(
-      Collection<com.google.sps.Event> events, Collection<String> attendees, int desiredDuration) {
+      Collection<Event> events, Collection<String> attendees, int desiredDuration) {
     return findAvailableTimeRangesForAttendees(events, attendees, desiredDuration);
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -45,16 +45,7 @@ public final class FindMeetingQuery {
   public Collection<TimeRange> query(
       Collection<Event> events, MeetingRequest request) {
 
-    // Array of queries representing times to meet.
-    List<TimeRange> optionalTimeRanges;
-
-    // Array of queries representing times to meet.
-    List<TimeRange> mandatoryTimeRanges;
-
     int desiredDuration = (int) request.getDuration();
-
-    // Array of queries representing times to meet.
-    List<TimeRange> allTimeRanges;
 
     // Check if duration of event is longer than a whole day and if so return empty.
     if ((int) request.getDuration() > WHOLE_DAY.duration()) {
@@ -69,20 +60,24 @@ public final class FindMeetingQuery {
 
     // If there are no mandatory attendees , return lists of the optional attendees time ranges.
     if (mandatoryAttendees.isEmpty()) {
-      optionalTimeRanges = populateTimeRanges(events, optionalAttendees, desiredDuration);
-      return optionalTimeRanges;    }
+        List<TimeRange> optionalTimeRanges = populateTimeRanges(events, optionalAttendees, desiredDuration);
+        return optionalTimeRanges;   
+    }
 
     // If there are no optional attendees , return lists of the mandatory attendees time ranges.
     if (optionalAttendees.isEmpty()) {
-      mandatoryTimeRanges = populateTimeRanges(events, mandatoryAttendees, desiredDuration);
-      return mandatoryTimeRanges;    }
+      List<TimeRange> mandatoryTimeRanges = populateTimeRanges(events, mandatoryAttendees, desiredDuration);
+      return mandatoryTimeRanges;   
+       }
 
     // Collection of Strings representing all attendees ( Mandatory and Optional )
     Collection<String> allAttendees =
         combineMandatoryAndOptional(mandatoryAttendees, optionalAttendees);
 
-    allTimeRanges =
-        (ArrayList<TimeRange>) findAvailableTimeRangesForAttendees(events, allAttendees, desiredDuration);
+    // List of queries representing times to meet.
+    List<TimeRange> allTimeRanges;
+
+    allTimeRanges = findAvailableTimeRangesForAttendees(events, allAttendees, desiredDuration);
     if (allTimeRanges.isEmpty()) {
       mandatoryTimeRanges = populateTimeRanges(events, mandatoryAttendees, desiredDuration);
       return mandatoryTimeRanges;
@@ -157,6 +152,7 @@ public final class FindMeetingQuery {
     allAttendees.addAll(mandatoryAttendees);
     return allAttendees;
   }
+
   public List<TimeRange> populateTimeRanges(
       Collection<Event> events, Collection<String> attendees, int desiredDuration) {
     return findAvailableTimeRangesForAttendees(events, attendees, desiredDuration);

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -12,20 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package com.google.sps;
 
 import java.util.ArrayList;
@@ -42,8 +28,7 @@ public final class FindMeetingQuery {
   private static final TimeRange WHOLE_DAY = TimeRange.WHOLE_DAY;
   private static final Comparator<TimeRange> ORDER_BY_START = TimeRange.ORDER_BY_START;
 
-  public Collection<TimeRange> query(
-      Collection<Event> events, MeetingRequest request) {
+  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
 
     int desiredDuration = (int) request.getDuration();
 
@@ -60,32 +45,35 @@ public final class FindMeetingQuery {
 
     // If there are no mandatory attendees , return lists of the optional attendees time ranges.
     if (mandatoryAttendees.isEmpty()) {
-        List<TimeRange> optionalTimeRanges = populateTimeRanges(events, optionalAttendees, desiredDuration);
-        return optionalTimeRanges;   
+      List<TimeRange> optionalTimeRanges =
+          populateTimeRanges(events, optionalAttendees, desiredDuration);
+      return optionalTimeRanges;
     }
 
     // If there are no optional attendees , return lists of the mandatory attendees time ranges.
     if (optionalAttendees.isEmpty()) {
-      List<TimeRange> mandatoryTimeRanges = populateTimeRanges(events, mandatoryAttendees, desiredDuration);
-      return mandatoryTimeRanges;   
-       }
+      List<TimeRange> mandatoryTimeRanges =
+          populateTimeRanges(events, mandatoryAttendees, desiredDuration);
+      return mandatoryTimeRanges;
+    }
 
     // Collection of Strings representing all attendees ( Mandatory and Optional )
     Collection<String> allAttendees =
         combineMandatoryAndOptional(mandatoryAttendees, optionalAttendees);
 
     // List of queries representing times to meet.
-    List<TimeRange> allTimeRanges;
 
-    allTimeRanges = findAvailableTimeRangesForAttendees(events, allAttendees, desiredDuration);
+    List<TimeRange> allTimeRanges =
+        findAvailableTimeRangesForAttendees(events, allAttendees, desiredDuration);
     if (allTimeRanges.isEmpty()) {
-      List<TimeRange> mandatoryTimeRanges = populateTimeRanges(events, mandatoryAttendees, desiredDuration);
+      List<TimeRange> mandatoryTimeRanges =
+          populateTimeRanges(events, mandatoryAttendees, desiredDuration);
       return mandatoryTimeRanges;
     }
     return allTimeRanges;
   }
 
- public List<TimeRange> findAvailableTimeRangesForAttendees(
+  public List<TimeRange> findAvailableTimeRangesForAttendees(
       Collection<Event> events, Collection<String> attendees, int desiredDuration) {
 
     // Array of queries representing times to meet.
@@ -125,9 +113,7 @@ public final class FindMeetingQuery {
       // If this is a valid time range then add it to query .
       if (currentTime <= eventStart) {
         if (eventStart - currentTime >= desiredDuration) {
-          timeRanges.add(
-              TimeRange.fromStartEnd(
-                  currentTime, eventStart, /* inclusive= */ false));
+          timeRanges.add(TimeRange.fromStartEnd(currentTime, eventStart, /* inclusive= */ false));
         }
         nextTime = eventEnd;
       }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -79,7 +79,7 @@ public final class FindMeetingQuery {
 
     allTimeRanges = findAvailableTimeRangesForAttendees(events, allAttendees, desiredDuration);
     if (allTimeRanges.isEmpty()) {
-      mandatoryTimeRanges = populateTimeRanges(events, mandatoryAttendees, desiredDuration);
+      List<TimeRange> mandatoryTimeRanges = populateTimeRanges(events, mandatoryAttendees, desiredDuration);
       return mandatoryTimeRanges;
     }
     return allTimeRanges;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -12,9 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 
 public final class FindMeetingQuery {
 
@@ -23,30 +42,60 @@ public final class FindMeetingQuery {
   private static final TimeRange WHOLE_DAY = TimeRange.WHOLE_DAY;
   private static final Comparator<TimeRange> ORDER_BY_START = TimeRange.ORDER_BY_START;
 
-  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
+  public Collection<TimeRange> query(
+      Collection<Event> events, MeetingRequest request) {
 
     // Array of queries representing times to meet.
-    List<TimeRange> query = new ArrayList<>();
+    List<TimeRange> optionalTimeRanges;
+
+    // Array of queries representing times to meet.
+    List<TimeRange> mandatoryTimeRanges;
+
+    // Array of queries representing times to meet.
+    List<TimeRange> allTimeRanges;
 
     int desiredDuration = (int) request.getDuration();
 
     // Collection of string representing who is to attend the requested meeting.
-    Collection<String> allAttendees = new ArrayList<>(request.getAttendees());
+    Collection<String> mandatoryAttendees = new ArrayList<>(request.getAttendees());
+
     // Collection of strings representing who are optional to the meeting.
     Collection<String> optionalAttendees = new ArrayList<>(request.getOptionalAttendees());
-    // Combine the optional and mandatory attendees to a single collection
-    allAttendees.addAll(optionalAttendees);
+
+    // Collection of Strings representing all attendees ( Mandatory and Optional )
+    Collection<String> allAttendees =
+        combineMandatoryAndOptional(mandatoryAttendees, optionalAttendees);
 
     // Check if duration of event is longer than a whole day and if so return empty.
     if ((int) request.getDuration() > WHOLE_DAY.duration()) {
-      return query;
+      return Collections.emptyList();
     }
 
-    // Check if there are any events happening at all if so return whole day query.
-    if (events.size() == 0) {
-      query.add(com.google.sps.TimeRange.WHOLE_DAY);
-      return query;
+    // If there are no mandatory attendees , return lists of the optional attendees time ranges.
+    if (mandatoryAttendees.isEmpty()) {
+        return getTimeRanges(events, optionalAttendees, desiredDuration);
     }
+
+    // If there are no optional attendees , return lists of the mandatory attendees time ranges.
+    if (optionalAttendees.isEmpty()) {
+        return getTimeRanges(events, mandatoryAttendees, desiredDuration);
+    }
+
+    allTimeRanges =
+        (ArrayList<TimeRange>) getTimeRanges(events, allAttendees, desiredDuration);
+    if (allTimeRanges.isEmpty()) {
+        return getTimeRanges(events, mandatoryAttendees, desiredDuration);
+    }
+    return allTimeRanges;
+  }
+
+ public List<TimeRange> getTimeRanges(
+      Collection<Event> events, Collection<String> attendees, int desiredDuration) {
+
+    // Array of queries representing times to meet.
+    List<TimeRange> timeRanges = new ArrayList<>();
+
+    int nextTime = START_OF_DAY;
 
     // Copy of events used for iterating and sorting.
     List<Event> eventsCopy = new ArrayList<>(events);
@@ -54,17 +103,21 @@ public final class FindMeetingQuery {
     // Sorts the even in chronological order.
     eventsCopy.sort((e1, e2) -> ORDER_BY_START.compare(e1.getWhen(), e2.getWhen()));
 
-    int nextTime = START_OF_DAY;
+    // Check if there are any events happening at all if so return whole day query.
+    if (events.isEmpty()) {
+      timeRanges.add(TimeRange.WHOLE_DAY);
+      return timeRanges;
+    }
 
     // Iterating through input event collection.
-    for (com.google.sps.Event event : eventsCopy) {
+    for (Event event : eventsCopy) {
       int currentTime = nextTime;
 
       // Collection of the people who can attend meeting.
       Set<String> eventAttendees = event.getAttendees();
 
       // If the none of the attendees are capable of attending skip this event
-      if (Collections.disjoint(eventAttendees, allAttendees)) {
+      if (Collections.disjoint(eventAttendees, attendees)) {
         continue;
       }
 
@@ -76,7 +129,9 @@ public final class FindMeetingQuery {
       // If this is a valid time range then add it to query .
       if (currentTime <= eventStart) {
         if (eventStart - currentTime >= desiredDuration) {
-          query.add(TimeRange.fromStartEnd(currentTime, eventStart, /* inclusive= */ false));
+          timeRanges.add(
+              TimeRange.fromStartEnd(
+                  currentTime, eventStart, /* inclusive= */ false));
         }
         nextTime = eventEnd;
       }
@@ -88,8 +143,21 @@ public final class FindMeetingQuery {
     }
     // If at the last event and there is still time in the day.
     if (nextTime < END_OF_DAY) {
-      query.add(TimeRange.fromStartEnd(nextTime, END_OF_DAY, /* inclusive= */ true));
+      timeRanges.add(TimeRange.fromStartEnd(nextTime, END_OF_DAY, /* inclusive= */ true));
     }
-    return query;
+    return timeRanges;
+  }
+
+  public Collection<String> combineMandatoryAndOptional(
+      Collection<String> mandatoryAttendees, Collection<String> optionalAttendees) {
+    // Collection of Strings representing all attendees ( Mandatory and Optional )
+    Collection<String> allAttendees = new ArrayList<>();
+    allAttendees.addAll(optionalAttendees);
+    allAttendees.addAll(mandatoryAttendees);
+    return allAttendees;
+  }
+  public List<TimeRange> populateTimeRanges(
+      Collection<com.google.sps.Event> events, Collection<String> attendees, int desiredDuration) {
+    return getTimeRanges(events, attendees, desiredDuration);
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -14,8 +14,6 @@
 
 package com.google.sps;
 
-import static java.util.Arrays.*;
-import static java.util.Arrays.asList;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -81,7 +79,7 @@ public final class FindMeetingQueryTest {
   public void eventSplitsRestriction() {
     // The event should split the day into two options (before and after the event).
     Collection<Event> events =
-        asList(
+       Arrays.asList(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
@@ -92,7 +90,7 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        asList(
+        Arrays.asList(
             TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
 
@@ -109,7 +107,7 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|     |--2--|     |--3--|
 
     Collection<Event> events =
-        asList(
+        Arrays.asList(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
@@ -119,11 +117,11 @@ public final class FindMeetingQueryTest {
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
                 Collections.singletonList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        asList(
+        Arrays.asList(
             TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
@@ -141,7 +139,7 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|         |--2--|
 
     Collection<Event> events =
-        asList(
+        Arrays.asList(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
@@ -151,11 +149,11 @@ public final class FindMeetingQueryTest {
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
                 Collections.singletonList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        asList(
+        Arrays.asList(
             TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
@@ -173,7 +171,7 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|         |--2--|
 
     Collection<Event> events =
-        asList(
+        Arrays.asList(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
@@ -183,11 +181,11 @@ public final class FindMeetingQueryTest {
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
                 Collections.singletonList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        asList(
+        Arrays.asList(
             TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
@@ -204,7 +202,7 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|         |--2--|
 
     Collection<Event> events =
-        asList(
+        Arrays.asList(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
@@ -219,7 +217,7 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        asList(
+        Arrays.asList(
             TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
@@ -236,11 +234,11 @@ public final class FindMeetingQueryTest {
     // Options :       |-----|
 
     Collection<Event> events =
-        asList(
+        Arrays.asList(
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-                asList(PERSON_A)),
+                Arrays.asList(PERSON_A)),
             new Event(
                 "Event 2",
                 TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
@@ -251,7 +249,7 @@ public final class FindMeetingQueryTest {
 
     Collection<com.google.sps.TimeRange> actual = query.query(events, request);
     Collection<com.google.sps.TimeRange> expected =
-        asList(com.google.sps.TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+        Arrays.asList(com.google.sps.TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
 
     Assert.assertEquals(expected, actual);
   }
@@ -261,7 +259,7 @@ public final class FindMeetingQueryTest {
     // Add an event, but make the only attendee someone different from the person looking to book
     // a meeting. This event should not affect the booking.
     Collection<com.google.sps.Event> events =
-        asList(
+        Arrays.asList(
             new com.google.sps.Event(
                 "Event 1",
                 com.google.sps.TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
@@ -277,7 +275,7 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void noConflicts() {
-    MeetingRequest request = new MeetingRequest(asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(NO_EVENTS, request);
     Collection<TimeRange> expected = Collections.singletonList(TimeRange.WHOLE_DAY);
@@ -295,7 +293,7 @@ public final class FindMeetingQueryTest {
     // Options :
 
     Collection<Event> events =
-        asList(
+        Arrays.asList(
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
@@ -322,7 +320,7 @@ public final class FindMeetingQueryTest {
     String testPerson = "Person Jordan";
 
     Collection<com.google.sps.Event> events =
-        asList(
+        Arrays.asList(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
@@ -333,12 +331,12 @@ public final class FindMeetingQueryTest {
                 Collections.singletonList(PERSON_B)),
             new Event("Event 3", TimeRange.WHOLE_DAY, Collections.singletonList(testPerson)));
 
-    MeetingRequest request = new MeetingRequest(asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
     request.addOptionalAttendee(testPerson);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        asList(
+        Arrays.asList(
             com.google.sps.TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             com.google.sps.TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
             com.google.sps.TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
@@ -346,8 +344,6 @@ public final class FindMeetingQueryTest {
     Assert.assertEquals(expected, actual);
   }
 
-  @Test
-  public void optionalAttendeeEarly() {}
 
   @Test
   public void optionalJustEnoughRoom() {
@@ -355,11 +351,11 @@ public final class FindMeetingQueryTest {
     String testPerson = "Person Nadroj";
 
     Collection<Event> events =
-        asList(
+        Arrays.asList(
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-                asList(PERSON_A)),
+                Arrays.asList(PERSON_A)),
             new Event(
                 "Event 2",
                 TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
@@ -375,14 +371,14 @@ public final class FindMeetingQueryTest {
 
     Collection<com.google.sps.TimeRange> actual = query.query(events, request);
     Collection<com.google.sps.TimeRange> expected =
-        asList(com.google.sps.TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+        Arrays.asList(com.google.sps.TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
     Assert.assertEquals(expected, actual);
   }
 
   @Test
   public void noMandatoryAttendeesNoGaps() {
     Collection<Event> events =
-        asList(
+        Arrays.asList(
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, false),
@@ -405,7 +401,7 @@ public final class FindMeetingQueryTest {
   @Test
   public void noMandatoryAttendeesGaps() {
     Collection<Event> events =
-        asList(
+        Arrays.asList(
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0930AM, false),
@@ -439,13 +435,13 @@ public final class FindMeetingQueryTest {
     Collection<com.google.sps.TimeRange> actual = query.query(events, request);
 
     Collection<com.google.sps.TimeRange> expected =
-        asList(
+        Arrays.asList(
             TimeRange.fromStartEnd(
                 TimeRange.getTimeInMinutes(9, 30), TimeRange.getTimeInMinutes(10, 0), false),
             TimeRange.fromStartEnd(
                 TimeRange.getTimeInMinutes(10, 30), TimeRange.getTimeInMinutes(14, 0), false),
             TimeRange.fromStartEnd(
-                TimeRange.getTimeInMinutes(16, 30), TimeRange.getTimeInMinutes(17, 0), true));
+                TimeRange.getTimeInMinutes(16, 30), TimeRange.getTimeInMinutes(17, 0), false));
     Assert.assertEquals(expected, actual);
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -14,11 +14,12 @@
 
 package com.google.sps;
 
-import java.util.ArrayList;
+import static java.util.Arrays.*;
+import static java.util.Arrays.asList;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,13 +42,11 @@ public final class FindMeetingQueryTest {
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
-  private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
   private static final int DURATION_1_HOUR = 60;
-  private static final int DURATION_2_HOUR = 120;
 
   private FindMeetingQuery query;
 
@@ -61,7 +60,7 @@ public final class FindMeetingQueryTest {
     MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_1_HOUR);
 
     Collection<TimeRange> actual = query.query(NO_EVENTS, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
+    Collection<TimeRange> expected = Collections.singletonList(TimeRange.WHOLE_DAY);
 
     Assert.assertEquals(expected, actual);
   }
@@ -70,10 +69,10 @@ public final class FindMeetingQueryTest {
   public void noOptionsForTooLongOfARequest() {
     // The duration should be longer than a day. This means there should be no options.
     int duration = TimeRange.WHOLE_DAY.duration() + 1;
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), duration);
+    MeetingRequest request = new MeetingRequest(Collections.singletonList(PERSON_A), duration);
 
     Collection<TimeRange> actual = query.query(NO_EVENTS, request);
-    Collection<TimeRange> expected = Arrays.asList();
+    Collection<TimeRange> expected = Collections.emptyList();
 
     Assert.assertEquals(expected, actual);
   }
@@ -81,14 +80,20 @@ public final class FindMeetingQueryTest {
   @Test
   public void eventSplitsRestriction() {
     // The event should split the day into two options (before and after the event).
-    Collection<Event> events = Arrays.asList(new Event("Event 1",
-        TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
+    Collection<Event> events =
+        asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+                Collections.singletonList(PERSON_A)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    MeetingRequest request =
+        new MeetingRequest(Collections.singletonList(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -103,18 +108,23 @@ public final class FindMeetingQueryTest {
     // Day     : |-----------------------------|
     // Options : |--1--|     |--2--|     |--3--|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_B)));
+    Collection<Event> events =
+        asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Collections.singletonList(PERSON_B)));
 
-    MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+        asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
@@ -130,18 +140,23 @@ public final class FindMeetingQueryTest {
     // Day     : |---------------------|
     // Options : |--1--|         |--2--|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
-            Arrays.asList(PERSON_B)));
+    Collection<Event> events =
+        asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
+                Collections.singletonList(PERSON_B)));
 
-    MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -157,18 +172,23 @@ public final class FindMeetingQueryTest {
     // Day     : |---------------------|
     // Options : |--1--|         |--2--|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_B)));
+    Collection<Event> events =
+        asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Collections.singletonList(PERSON_B)));
 
-    MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -183,17 +203,24 @@ public final class FindMeetingQueryTest {
     // Day     : |---------------------|
     // Options : |--1--|         |--2--|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_A)));
+    Collection<Event> events =
+        asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Collections.singletonList(PERSON_A)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    MeetingRequest request =
+        new MeetingRequest(Collections.singletonList(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -208,17 +235,23 @@ public final class FindMeetingQueryTest {
     // Day     : |---------------------|
     // Options :       |-----|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
-            Arrays.asList(PERSON_A)));
+    Collection<Event> events =
+        asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                Collections.singletonList(PERSON_A)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    MeetingRequest request =
+        new MeetingRequest(Collections.singletonList(PERSON_A), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+    Collection<com.google.sps.TimeRange> actual = query.query(events, request);
+    Collection<com.google.sps.TimeRange> expected =
+        asList(com.google.sps.TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
 
     Assert.assertEquals(expected, actual);
   }
@@ -227,23 +260,27 @@ public final class FindMeetingQueryTest {
   public void ignoresPeopleNotAttending() {
     // Add an event, but make the only attendee someone different from the person looking to book
     // a meeting. This event should not affect the booking.
-    Collection<Event> events = Arrays.asList(new Event("Event 1",
-        TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_B), DURATION_30_MINUTES);
+    Collection<com.google.sps.Event> events =
+        asList(
+            new com.google.sps.Event(
+                "Event 1",
+                com.google.sps.TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Collections.singletonList(PERSON_A)));
+    MeetingRequest request =
+        new MeetingRequest(Collections.singletonList(PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
+    Collection<TimeRange> expected = Collections.singletonList(TimeRange.WHOLE_DAY);
 
     Assert.assertEquals(expected, actual);
   }
 
   @Test
   public void noConflicts() {
-    MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(NO_EVENTS, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
+    Collection<TimeRange> expected = Collections.singletonList(TimeRange.WHOLE_DAY);
 
     Assert.assertEquals(expected, actual);
   }
@@ -257,18 +294,158 @@ public final class FindMeetingQueryTest {
     // Day     : |---------------------|
     // Options :
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
-            Arrays.asList(PERSON_A)));
+    Collection<Event> events =
+        asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                Collections.singletonList(PERSON_A)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+    MeetingRequest request =
+        new MeetingRequest(Collections.singletonList(PERSON_A), DURATION_60_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList();
+    Collection<TimeRange> expected = Collections.emptyList();
 
     Assert.assertEquals(expected, actual);
   }
-}
 
+  @Test
+  public void optionalAttendeeConsidered() {
+    // Add an optional attendee C who has an all-day event. The same three time slots should be
+    // returned as when C was not invited.
+
+    String testPerson = "Person Jordan";
+
+    Collection<com.google.sps.Event> events =
+        asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Collections.singletonList(PERSON_B)),
+            new Event("Event 3", TimeRange.WHOLE_DAY, Collections.singletonList(testPerson)));
+
+    MeetingRequest request = new MeetingRequest(asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(testPerson);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        asList(
+            com.google.sps.TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            com.google.sps.TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            com.google.sps.TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeEarly() {}
+
+  @Test
+  public void optionalJustEnoughRoom() {
+
+    String testPerson = "Person Nadroj";
+
+    Collection<Event> events =
+        asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartDuration(TIME_0830AM, 15),
+                Collections.singletonList(testPerson)));
+
+    MeetingRequest request =
+        new MeetingRequest(Collections.singletonList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(testPerson);
+
+    Collection<com.google.sps.TimeRange> actual = query.query(events, request);
+    Collection<com.google.sps.TimeRange> expected =
+        asList(com.google.sps.TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void noMandatoryAttendeesNoGaps() {
+    Collection<Event> events =
+        asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, false),
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true),
+                Collections.singletonList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Collections.emptyList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<com.google.sps.TimeRange> actual = query.query(events, request);
+
+    Collection<com.google.sps.TimeRange> expected = Collections.emptyList();
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void noMandatoryAttendeesGaps() {
+    Collection<Event> events =
+        asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0930AM, false),
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_1000AM, 30),
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartDuration(TimeRange.getTimeInMinutes(16, 0), 30),
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 4",
+                TimeRange.fromStartEnd(
+                    TimeRange.getTimeInMinutes(17, 0), TimeRange.END_OF_DAY, true),
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 1.5",
+                TimeRange.fromStartDuration(TimeRange.getTimeInMinutes(9, 0), 30),
+                Collections.singletonList(PERSON_B)),
+            new Event(
+                "Event 5",
+                TimeRange.fromStartDuration(TimeRange.getTimeInMinutes(14, 0), 120),
+                Collections.singletonList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Collections.emptyList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<com.google.sps.TimeRange> actual = query.query(events, request);
+
+    Collection<com.google.sps.TimeRange> expected =
+        asList(
+            TimeRange.fromStartEnd(
+                TimeRange.getTimeInMinutes(9, 30), TimeRange.getTimeInMinutes(10, 0), false),
+            TimeRange.fromStartEnd(
+                TimeRange.getTimeInMinutes(10, 30), TimeRange.getTimeInMinutes(14, 0), false),
+            TimeRange.fromStartEnd(
+                TimeRange.getTimeInMinutes(16, 30), TimeRange.getTimeInMinutes(17, 0), true));
+    Assert.assertEquals(expected, actual);
+  }
+}

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -437,6 +437,7 @@ public final class FindMeetingQueryTest {
     // Options :                |---|
     // Options :                                  |-|
 
+      
     Collection<Event> events =
         Arrays.asList(
             new Event(
@@ -444,17 +445,9 @@ public final class FindMeetingQueryTest {
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0930AM, false),
                 Collections.singletonList(PERSON_A)),
             new Event(
-                "Event 1.5",
-                TimeRange.fromStartDuration(TimeRange.getTimeInMinutes(9, 0), 30),
-                Collections.singletonList(PERSON_B)),
-            new Event(
                 "Event 2",
                 TimeRange.fromStartDuration(TIME_1000AM, 30),
                 Collections.singletonList(PERSON_A)),
-            new Event(
-                "Event 5",
-                TimeRange.fromStartDuration(TimeRange.getTimeInMinutes(14, 0), 120),
-                Collections.singletonList(PERSON_B)),
             new Event(
                 "Event 3",
                 TimeRange.fromStartDuration(TimeRange.getTimeInMinutes(16, 0), 30),
@@ -463,7 +456,15 @@ public final class FindMeetingQueryTest {
                 "Event 4",
                 TimeRange.fromStartEnd(
                     TimeRange.getTimeInMinutes(17, 0), TimeRange.END_OF_DAY, true),
-                Collections.singletonList(PERSON_A)));
+                Collections.singletonList(PERSON_A)),
+            new Event(
+                "Event 1.5",
+                TimeRange.fromStartDuration(TimeRange.getTimeInMinutes(9, 0), 30),
+                Collections.singletonList(PERSON_B)),
+            new Event(
+                "Event 5",
+                TimeRange.fromStartDuration(TimeRange.getTimeInMinutes(14, 0), 120),
+                Collections.singletonList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Collections.emptyList(), DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_A);
@@ -478,7 +479,7 @@ public final class FindMeetingQueryTest {
             TimeRange.fromStartEnd(
                 TimeRange.getTimeInMinutes(10, 30), TimeRange.getTimeInMinutes(14, 0), false),
             TimeRange.fromStartEnd(
-                TimeRange.getTimeInMinutes(16, 30), TimeRange.getTimeInMinutes(17, 0), true));
+                TimeRange.getTimeInMinutes(16, 30), TimeRange.getTimeInMinutes(17, 0), false));
     Assert.assertEquals(expected, actual);
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -14,7 +14,6 @@
 
 package com.google.sps;
 
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -78,7 +79,7 @@ public final class FindMeetingQueryTest {
   public void eventSplitsRestriction() {
     // The event should split the day into two options (before and after the event).
     Collection<Event> events =
-       Arrays.asList(
+       ImmutableList.of(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
@@ -89,7 +90,7 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(
+        ImmutableList.of(
             TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
 
@@ -106,7 +107,7 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|     |--2--|     |--3--|
 
     Collection<Event> events =
-        Arrays.asList(
+        ImmutableList.of(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
@@ -116,11 +117,11 @@ public final class FindMeetingQueryTest {
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
                 Collections.singletonList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(ImmutableList.of(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(
+        ImmutableList.of(
             TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
@@ -138,7 +139,7 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|         |--2--|
 
     Collection<Event> events =
-        Arrays.asList(
+        ImmutableList.of(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
@@ -148,11 +149,11 @@ public final class FindMeetingQueryTest {
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
                 Collections.singletonList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(ImmutableList.of(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(
+        ImmutableList.of(
             TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
@@ -170,7 +171,7 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|         |--2--|
 
     Collection<Event> events =
-        Arrays.asList(
+        ImmutableList.of(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
@@ -180,11 +181,11 @@ public final class FindMeetingQueryTest {
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
                 Collections.singletonList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(ImmutableList.of(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(
+        ImmutableList.of(
             TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
@@ -201,7 +202,7 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|         |--2--|
 
     Collection<Event> events =
-        Arrays.asList(
+        ImmutableList.of(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
@@ -216,7 +217,7 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(
+        ImmutableList.of(
             TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
@@ -233,11 +234,11 @@ public final class FindMeetingQueryTest {
     // Options :       |-----|
 
     Collection<Event> events =
-        Arrays.asList(
+        ImmutableList.of(
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-                Arrays.asList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 2",
                 TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
@@ -248,7 +249,7 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+        ImmutableList.of(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
 
     Assert.assertEquals(expected, actual);
   }
@@ -258,7 +259,7 @@ public final class FindMeetingQueryTest {
     // Add an event, but make the only attendee someone different from the person looking to book
     // a meeting. This event should not affect the booking.
     Collection<Event> events =
-        Arrays.asList(
+        ImmutableList.of(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
@@ -274,7 +275,7 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void noConflicts() {
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(ImmutableList.of(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(NO_EVENTS, request);
     Collection<TimeRange> expected = Collections.singletonList(TimeRange.WHOLE_DAY);
@@ -292,7 +293,7 @@ public final class FindMeetingQueryTest {
     // Options :
 
     Collection<Event> events =
-        Arrays.asList(
+        ImmutableList.of(
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
@@ -327,7 +328,7 @@ public final class FindMeetingQueryTest {
     String PERSON_J = "Person Jordan";
 
     Collection<Event> events =
-        Arrays.asList(
+        ImmutableList.of(
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
@@ -338,12 +339,12 @@ public final class FindMeetingQueryTest {
                 Collections.singletonList(PERSON_B)),
             new Event("Event 3", TimeRange.WHOLE_DAY, Collections.singletonList(PERSON_J)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(ImmutableList.of(PERSON_A, PERSON_B), DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_J);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(
+        ImmutableList.of(
             TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
@@ -367,7 +368,7 @@ public final class FindMeetingQueryTest {
     String PERSON_N = "Person Nadroj";
 
     Collection<Event> events =
-        Arrays.asList(
+        ImmutableList.of(
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
@@ -403,7 +404,7 @@ public final class FindMeetingQueryTest {
     // Options :
 
     Collection<Event> events =
-        Arrays.asList(
+        ImmutableList.of(
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, false),
@@ -438,7 +439,7 @@ public final class FindMeetingQueryTest {
 
       
     Collection<Event> events =
-        Arrays.asList(
+        ImmutableList.of(
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0930AM, false),
@@ -472,7 +473,7 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> actual = query.query(events, request);
 
     Collection<TimeRange> expected =
-        Arrays.asList(
+        ImmutableList.of(
             TimeRange.fromStartEnd(
                 TimeRange.getTimeInMinutes(9, 30), TimeRange.getTimeInMinutes(10, 0), false),
             TimeRange.fromStartEnd(

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -17,7 +17,6 @@ package com.google.sps;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,8 +26,8 @@ import org.junit.runners.JUnit4;
 /** */
 @RunWith(JUnit4.class)
 public final class FindMeetingQueryTest {
-  private static final Collection<Event> NO_EVENTS = Collections.emptySet();
-  private static final Collection<String> NO_ATTENDEES = Collections.emptySet();
+  private static final Collection<Event> NO_EVENTS = ImmutableList.of();
+  private static final Collection<String> NO_ATTENDEES = ImmutableList.of();
 
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
@@ -58,7 +57,7 @@ public final class FindMeetingQueryTest {
     MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_1_HOUR);
 
     Collection<TimeRange> actual = query.query(NO_EVENTS, request);
-    Collection<TimeRange> expected = Collections.singletonList(TimeRange.WHOLE_DAY);
+    Collection<TimeRange> expected = ImmutableList.of(TimeRange.WHOLE_DAY);
 
     Assert.assertEquals(expected, actual);
   }
@@ -67,10 +66,10 @@ public final class FindMeetingQueryTest {
   public void noOptionsForTooLongOfARequest() {
     // The duration should be longer than a day. This means there should be no options.
     int duration = TimeRange.WHOLE_DAY.duration() + 1;
-    MeetingRequest request = new MeetingRequest(Collections.singletonList(PERSON_A), duration);
+    MeetingRequest request = new MeetingRequest(ImmutableList.of(PERSON_A), duration);
 
     Collection<TimeRange> actual = query.query(NO_EVENTS, request);
-    Collection<TimeRange> expected = Collections.emptyList();
+    Collection<TimeRange> expected = ImmutableList.of();
 
     Assert.assertEquals(expected, actual);
   }
@@ -83,10 +82,10 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
-                Collections.singletonList(PERSON_A)));
+                ImmutableList.of(PERSON_A)));
 
     MeetingRequest request =
-        new MeetingRequest(Collections.singletonList(PERSON_A), DURATION_30_MINUTES);
+        new MeetingRequest(ImmutableList.of(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
@@ -111,11 +110,11 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
-                Collections.singletonList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 2",
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-                Collections.singletonList(PERSON_B)));
+                ImmutableList.of(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(ImmutableList.of(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
@@ -143,11 +142,11 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
-                Collections.singletonList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 2",
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
-                Collections.singletonList(PERSON_B)));
+                ImmutableList.of(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(ImmutableList.of(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
@@ -175,11 +174,11 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
-                Collections.singletonList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 2",
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-                Collections.singletonList(PERSON_B)));
+                ImmutableList.of(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(ImmutableList.of(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
@@ -206,14 +205,14 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
-                Collections.singletonList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 2",
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-                Collections.singletonList(PERSON_A)));
+                ImmutableList.of(PERSON_A)));
 
     MeetingRequest request =
-        new MeetingRequest(Collections.singletonList(PERSON_A), DURATION_30_MINUTES);
+        new MeetingRequest(ImmutableList.of(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
@@ -242,10 +241,10 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 2",
                 TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
-                Collections.singletonList(PERSON_A)));
+                ImmutableList.of(PERSON_A)));
 
     MeetingRequest request =
-        new MeetingRequest(Collections.singletonList(PERSON_A), DURATION_30_MINUTES);
+        new MeetingRequest(ImmutableList.of(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
@@ -263,12 +262,12 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-                Collections.singletonList(PERSON_A)));
+                ImmutableList.of(PERSON_A)));
     MeetingRequest request =
-        new MeetingRequest(Collections.singletonList(PERSON_B), DURATION_30_MINUTES);
+        new MeetingRequest(ImmutableList.of(PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Collections.singletonList(TimeRange.WHOLE_DAY);
+    Collection<TimeRange> expected = ImmutableList.of(TimeRange.WHOLE_DAY);
 
     Assert.assertEquals(expected, actual);
   }
@@ -278,7 +277,7 @@ public final class FindMeetingQueryTest {
     MeetingRequest request = new MeetingRequest(ImmutableList.of(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(NO_EVENTS, request);
-    Collection<TimeRange> expected = Collections.singletonList(TimeRange.WHOLE_DAY);
+    Collection<TimeRange> expected = ImmutableList.of(TimeRange.WHOLE_DAY);
 
     Assert.assertEquals(expected, actual);
   }
@@ -297,17 +296,17 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-                Collections.singletonList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 2",
                 TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
-                Collections.singletonList(PERSON_A)));
+                ImmutableList.of(PERSON_A)));
 
     MeetingRequest request =
-        new MeetingRequest(Collections.singletonList(PERSON_A), DURATION_60_MINUTES);
+        new MeetingRequest(ImmutableList.of(PERSON_A), DURATION_60_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Collections.emptyList();
+    Collection<TimeRange> expected = ImmutableList.of();
 
     Assert.assertEquals(expected, actual);
   }
@@ -332,12 +331,12 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 1",
                 TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
-                Collections.singletonList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 2",
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-                Collections.singletonList(PERSON_B)),
-            new Event("Event 3", TimeRange.WHOLE_DAY, Collections.singletonList(PERSON_J)));
+                ImmutableList.of(PERSON_B)),
+            new Event("Event 3", TimeRange.WHOLE_DAY, ImmutableList.of(PERSON_J)));
 
     MeetingRequest request = new MeetingRequest(ImmutableList.of(PERSON_A, PERSON_B), DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_J);
@@ -372,23 +371,23 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-                    Collections.singletonList(PERSON_A)),
+                    ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 2",
                 TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
-                Collections.singletonList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 3",
                 TimeRange.fromStartDuration(TIME_0830AM, 15),
-                Collections.singletonList(PERSON_N)));
+                ImmutableList.of(PERSON_N)));
 
     MeetingRequest request =
-        new MeetingRequest(Collections.singletonList(PERSON_A), DURATION_30_MINUTES);
+        new MeetingRequest(ImmutableList.of(PERSON_A), DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_N);
 
     Collection<com.google.sps.TimeRange> actual = query.query(events, request);
     Collection<com.google.sps.TimeRange> expected =
-            Collections.singletonList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+            ImmutableList.of(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
     Assert.assertEquals(expected, actual);
   }
 
@@ -408,19 +407,19 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, false),
-                Collections.singletonList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 2",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true),
-                Collections.singletonList(PERSON_B)));
+                ImmutableList.of(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Collections.emptyList(), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(ImmutableList.of(), DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_A);
     request.addOptionalAttendee(PERSON_B);
 
     Collection<com.google.sps.TimeRange> actual = query.query(events, request);
 
-    Collection<com.google.sps.TimeRange> expected = Collections.emptyList();
+    Collection<com.google.sps.TimeRange> expected = ImmutableList.of();
     Assert.assertEquals(expected, actual);
   }
 
@@ -443,30 +442,30 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 1",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0930AM, false),
-                Collections.singletonList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 2",
                 TimeRange.fromStartDuration(TIME_1000AM, 30),
-                Collections.singletonList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 3",
                 TimeRange.fromStartDuration(TimeRange.getTimeInMinutes(16, 0), 30),
-                Collections.singletonList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 4",
                 TimeRange.fromStartEnd(
                     TimeRange.getTimeInMinutes(17, 0), TimeRange.END_OF_DAY, true),
-                Collections.singletonList(PERSON_A)),
+                ImmutableList.of(PERSON_A)),
             new Event(
                 "Event 1.5",
                 TimeRange.fromStartDuration(TimeRange.getTimeInMinutes(9, 0), 30),
-                Collections.singletonList(PERSON_B)),
+                ImmutableList.of(PERSON_B)),
             new Event(
                 "Event 5",
                 TimeRange.fromStartDuration(TimeRange.getTimeInMinutes(14, 0), 120),
-                Collections.singletonList(PERSON_B)));
+                ImmutableList.of(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Collections.emptyList(), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(ImmutableList.of(), DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_A);
     request.addOptionalAttendee(PERSON_B);
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -247,9 +247,9 @@ public final class FindMeetingQueryTest {
     MeetingRequest request =
         new MeetingRequest(Collections.singletonList(PERSON_A), DURATION_30_MINUTES);
 
-    Collection<com.google.sps.TimeRange> actual = query.query(events, request);
-    Collection<com.google.sps.TimeRange> expected =
-        Arrays.asList(com.google.sps.TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
 
     Assert.assertEquals(expected, actual);
   }
@@ -258,11 +258,11 @@ public final class FindMeetingQueryTest {
   public void ignoresPeopleNotAttending() {
     // Add an event, but make the only attendee someone different from the person looking to book
     // a meeting. This event should not affect the booking.
-    Collection<com.google.sps.Event> events =
+    Collection<Event> events =
         Arrays.asList(
-            new com.google.sps.Event(
+            new Event(
                 "Event 1",
-                com.google.sps.TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
                 Collections.singletonList(PERSON_A)));
     MeetingRequest request =
         new MeetingRequest(Collections.singletonList(PERSON_B), DURATION_30_MINUTES);
@@ -319,7 +319,7 @@ public final class FindMeetingQueryTest {
 
     String testPerson = "Person Jordan";
 
-    Collection<com.google.sps.Event> events =
+    Collection<Event> events =
         Arrays.asList(
             new Event(
                 "Event 1",
@@ -337,9 +337,9 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
         Arrays.asList(
-            com.google.sps.TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            com.google.sps.TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
-            com.google.sps.TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -369,9 +369,9 @@ public final class FindMeetingQueryTest {
         new MeetingRequest(Collections.singletonList(PERSON_A), DURATION_30_MINUTES);
     request.addOptionalAttendee(testPerson);
 
-    Collection<com.google.sps.TimeRange> actual = query.query(events, request);
-    Collection<com.google.sps.TimeRange> expected =
-        Arrays.asList(com.google.sps.TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
     Assert.assertEquals(expected, actual);
   }
 
@@ -392,9 +392,9 @@ public final class FindMeetingQueryTest {
     request.addOptionalAttendee(PERSON_A);
     request.addOptionalAttendee(PERSON_B);
 
-    Collection<com.google.sps.TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> actual = query.query(events, request);
 
-    Collection<com.google.sps.TimeRange> expected = Collections.emptyList();
+    Collection<TimeRange> expected = Collections.emptyList();
     Assert.assertEquals(expected, actual);
   }
 
@@ -432,9 +432,9 @@ public final class FindMeetingQueryTest {
     request.addOptionalAttendee(PERSON_A);
     request.addOptionalAttendee(PERSON_B);
 
-    Collection<com.google.sps.TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> actual = query.query(events, request);
 
-    Collection<com.google.sps.TimeRange> expected =
+    Collection<TimeRange> expected =
         Arrays.asList(
             TimeRange.fromStartEnd(
                 TimeRange.getTimeInMinutes(9, 30), TimeRange.getTimeInMinutes(10, 0), false),

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -313,8 +313,16 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void optionalAttendeeConsidered() {
+
     // Add an optional attendee C who has an all-day event. The same three time slots should be
     // returned as when C was not invited.
+    // Person C is an optional attendee that has an all-day event.
+    // Should return same 3 options as everyAttendeeIsConsidered
+    //
+    // Events  :       |--A--|     |--B--|
+    // Events  : |--------------C--------------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
 
     String testPerson = "Person Jordan";
 
@@ -347,6 +355,15 @@ public final class FindMeetingQueryTest {
   @Test
   public void optionalJustEnoughRoom() {
 
+    // Have one mandatory and one optional attendee, but make it so that 
+    // the optional attendee is ignored, since it would result in smaller
+    // time slot
+    //
+    // Events  : |--A--|     |----A----|
+    // Events  :          |Nadroj|
+    // Day     : |---------------------|
+    // Options :       |-----|
+
     String testPerson = "Person Nadroj";
 
     Collection<Event> events =
@@ -376,6 +393,15 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void noMandatoryAttendeesNoGaps() {
+
+    // Two optional attendees with the no gaps in their schedules
+    // Should return no times
+    //
+    // Events  : |--A--||------A-------| 
+    // Events  : |---------B-----------|
+    // Day     : |---------------------|
+    // Options : 
+
     Collection<Event> events =
         Arrays.asList(
             new Event(
@@ -399,6 +425,17 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void noMandatoryAttendeesGaps() {
+
+    // Two optional attendees with the following gaps in their schedules
+    // Should return time slots that both attendees can attend
+    //
+    // Events  :      |--A--| 
+    // Events  :            |-B-|  |-B-|
+    // Day     : |---------------------|
+    // Options : |----|     
+    // Options :                |--|
+
+      
     Collection<Event> events =
         Arrays.asList(
             new Event(

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -313,7 +313,6 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void optionalAttendeeConsidered() {
-
     // Add an optional attendee C who has an all-day event. The same three time slots should be
     // returned as when C was not invited.
 


### PR DESCRIPTION
This PR seeks to finish the work from Week 5. It will also add the functionality of optional attendees, meaning that if one or more time slots exists so that both mandatory and optional attendees can attend, return those time slots. Otherwise, return the time slots that fit just the mandatory attendees.

These Are the tests for the additional scenario placed within Week 5, they include a

- Including  an optional attendee C who has an all-day event. The same three time slots should be returned as when C was not invited.

- Based on `everyAttendeeIsConsidered`, adds an optional attendee C who has an event between 8:30 and 9:00. Now only the early and late parts of the day should be returned.

- Based on the `justEnoughRoom` method , adds an optional attendee B who has an event between 8:30 and 8:45. The optional attendee should be ignored since considering their schedule would result in a time slot smaller than the requested time.

- No mandatory attendees, just two optional attendees with several gaps in their schedules. Those gaps should be identified and returned.
